### PR TITLE
Patch/peer dependency version

### DIFF
--- a/packages/plugins/typescript/urql-graphcache/package.json
+++ b/packages/plugins/typescript/urql-graphcache/package.json
@@ -37,7 +37,7 @@
     "test": "jest --no-watchman --config ../../../../jest.config.js"
   },
   "peerDependencies": {
-    "@urql/exchange-graphcache": "^5.2.0 || ^6.0.0",
+    "@urql/exchange-graphcache": "^5.2.0 || ^6.0.0 || ^7.0.0",
     "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
     "graphql-tag": "^2.0.0"
   },

--- a/packages/plugins/typescript/urql-graphcache/src/index.ts
+++ b/packages/plugins/typescript/urql-graphcache/src/index.ts
@@ -136,7 +136,7 @@ function getKeysConfig(
       })}>) => null | string`,
     );
     return keys;
-  }, []);
+  }, [] as string[]);
 
   return 'export type GraphCacheKeysConfig = {\n  ' + keys.join(',\n  ') + '\n}';
 }
@@ -149,6 +149,8 @@ function getResolversConfig(
   const objectTypes = [schema.getQueryType(), ...getObjectTypes(schema)];
 
   const resolvers = objectTypes.reduce((resolvers, parentType) => {
+    if (parentType == null) return [];
+
     const fields = Object.entries(parentType.getFields()).reduce((fields, [fieldName, field]) => {
       const args = Object.entries(field.args);
       const argsName = args.length
@@ -167,12 +169,12 @@ function getResolversConfig(
       );
 
       return fields;
-    }, []);
+    }, [] as string[]);
 
     resolvers.push(`  ${parentType.name}?: {\n    ` + fields.join(',\n    ') + '\n  }');
 
     return resolvers;
-  }, []);
+  }, [] as string[]);
 
   return resolvers;
 }
@@ -231,12 +233,12 @@ function getRootUpdatersConfig(
       );
 
       return fields;
-    }, []);
+    }, [] as string[]);
 
     resolvers.push(`  ${parentType.name}?: {\n    ` + fields.join(',\n    ') + '\n  }');
 
     return resolvers;
-  }, []);
+  }, [] as string[]);
 
   return {
     queryUpdaters,


### PR DESCRIPTION
パッケージの更新が止まっていて、peerDependency指定が@urql/graph-cacheのバージョン更新に追従できておらず、インストール時にエラーになってしまっていたため、peerDependencyを更新するパッチを当てます